### PR TITLE
Clean URLs from stage=Live since SilverStripe won't

### DIFF
--- a/src/Extensions/FilterIndexPageItemExtension.php
+++ b/src/Extensions/FilterIndexPageItemExtension.php
@@ -107,7 +107,7 @@ class FilterIndexPageItemExtension extends SiteTreeExtension implements IndexIte
         $data['Visible'] = $this->getPageVisibility($this->owner);
         $data['Title'] = $this->owner->Title;
         $data['Content'] = $this->owner->Content;
-        $data['Url'] = $this->owner->getAbsoluteLiveLink(false);
+        $data['Url'] = $this->cleanUrl($this->owner->getAbsoluteLiveLink(false));
 
         if (!isset($data[ElasticaService::SUGGEST_FIELD_NAME])) {
             $data[ElasticaService::SUGGEST_FIELD_NAME] = $this->fillSugest(['Title','Content'],$data);

--- a/src/Extensions/GridElementIndexExtension.php
+++ b/src/Extensions/GridElementIndexExtension.php
@@ -66,7 +66,7 @@ class GridElementIndexExtension extends DataExtension implements IndexItemInterf
         }
 
         if ($data['Visible']) {
-            $data['Url'] = $page->getAbsoluteLiveLink(false);
+            $data['Url'] = $this->cleanUrl($page->getAbsoluteLiveLink(false));
             $data['Title'] = $page->getTitle();
         }
 

--- a/src/Traits/FilterIndexItemTrait.php
+++ b/src/Traits/FilterIndexItemTrait.php
@@ -74,4 +74,9 @@ trait FilterIndexItemTrait
 
         return $this->getPageVisibility($page->getParent());
     }
+
+    private function cleanUrl(string $url): string
+    {
+        return explode('?', $url)[0];
+    }
 }


### PR DESCRIPTION
Regardless of using `getAbsoluteLiveLink(false)` SilverStripe was still giving us URLs with `?stage=Live`.
So instead we clean the URLs ourselves.