### PR TITLE
Only create indexes for extensions that are in use

### DIFF
--- a/src/Services/ElasticaService.php
+++ b/src/Services/ElasticaService.php
@@ -79,6 +79,9 @@ class ElasticaService
         Versioned::set_reading_mode(Versioned::LIVE);
 
         foreach ($this->getIndexClasses() as $indexer) {
+            if (count(ClassInfo::classesWithExtension($indexer)) === 0) {
+                continue;
+            }
 
             $indexName = $this->getindexName($indexer);
             $this->setIndex($indexName);


### PR DESCRIPTION
This would otherwise cause issues with unused extensions being indexes without mapping which causes errors when searching for fields that don't exist in that index.