### PR TITLE
WDM-39 add fluent compatibility

### DIFF
--- a/src/Services/ElasticaService.php
+++ b/src/Services/ElasticaService.php
@@ -49,6 +49,15 @@ final class ElasticaService
     public function setIndex(string $indexName): self
     {
         $this->extend('updateIndexName', $indexName);
+
+        if (class_exists('TractorCow\Fluent\State\FluentState')) {
+            $locale = strtolower(\TractorCow\Fluent\State\FluentState::singleton()->getLocale());
+
+            if (!str_contains($indexName, $locale)) {
+                $indexName .= '-' . strtolower($locale);
+            }
+        }
+
         $this->index = $this->client->getIndex($indexName);
 
         return $this;

--- a/src/Services/ElasticaService.php
+++ b/src/Services/ElasticaService.php
@@ -11,6 +11,7 @@ use Elastica\Query;
 use Elastica\ResultSet;
 use Elastica\Suggest;
 use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Versioned\Versioned;
@@ -18,6 +19,7 @@ use TheWebmen\Elastica\Extensions\FilterIndexDataObjectItemExtension;
 use TheWebmen\Elastica\Extensions\FilterIndexPageItemExtension;
 use TheWebmen\Elastica\Extensions\GridElementIndexExtension;
 use TheWebmen\Elastica\Interfaces\IndexItemInterface;
+use TractorCow\Fluent\State\FluentState;
 
 final class ElasticaService
 {
@@ -50,8 +52,8 @@ final class ElasticaService
     {
         $this->extend('updateIndexName', $indexName);
 
-        if (class_exists('TractorCow\Fluent\State\FluentState')) {
-            $locale = strtolower(\TractorCow\Fluent\State\FluentState::singleton()->getLocale());
+        if (ClassInfo::exists(FluentState::class)) {
+            $locale = strtolower(FluentState::singleton()->getLocale());
 
             if (!str_contains($indexName, $locale)) {
                 $indexName .= '-' . strtolower($locale);

--- a/src/Tasks/ElasticaReindexTask.php
+++ b/src/Tasks/ElasticaReindexTask.php
@@ -14,7 +14,20 @@ final class ElasticaReindexTask extends BuildTask
 
     public function run($request): void
     {
-        $elasticaService = ElasticaService::singleton();
-        $elasticaService->reindex();
+        if (!class_exists('TractorCow\Fluent\State\FluentState')) {
+            $elasticaService = ElasticaService::singleton();
+            $elasticaService->reindex();
+            return;
+        }
+
+        foreach (\TractorCow\Fluent\Model\Locale::get() as $locale) {
+            \TractorCow\Fluent\State\FluentState::singleton()
+                ->withState(static function (\TractorCow\Fluent\State\FluentState $state) use ($locale) {
+                    $state->setLocale($locale->Locale);
+
+                    $elastica = ElasticaService::singleton();
+                    $elastica->reindex();
+                });
+        }
     }
 }


### PR DESCRIPTION
- [  ] require it in a project that uses Fluent and this module (brand-sites)
- [  ] run `docker compose exec php ./vendor/silverstripe/framework/cli-script.php dev/tasks/elastica-reindex`
- [  ] observe it creates indexes for all locales with the suffix -$locale
- [  ] require it in a project uses this module but not Fluent ( pcbo-werkenbij)
- [  ] run `docker compose exec php ./vendor/silverstripe/framework/cli-script.php dev/tasks/elastica-reindex`
- [  ] observe it works as expected 